### PR TITLE
Update Google OAuth redirect URL to use environment variable for API URL

### DIFF
--- a/frontend/src/pages/AuthPage.jsx
+++ b/frontend/src/pages/AuthPage.jsx
@@ -17,7 +17,8 @@ const AuthPage = () => {
 
   const handleGoogleAuth = () => {
     // Redirect to backend Google OAuth endpoint
-    window.location.href = 'http://localhost:5000/auth/google';
+    const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+    window.location.href = `${API_URL}/auth/google`;
   };
 
   const handleSubmit = async (e) => {


### PR DESCRIPTION
Change the Google OAuth redirect URL to utilize an environment variable for better configuration management. This allows for easier updates to the API URL without modifying the code.